### PR TITLE
Ksinha45/top down cr

### DIFF
--- a/graphrag/config/create_graphrag_config.py
+++ b/graphrag/config/create_graphrag_config.py
@@ -471,6 +471,7 @@ def create_graphrag_config(
                 or defs.COMMUNITY_REPORT_MAX_LENGTH,
                 max_input_length=reader.int("max_input_length")
                 or defs.COMMUNITY_REPORT_MAX_INPUT_LENGTH,
+                local_context_pruning_strategy=reader.str("local_context_pruning_strategy")
             )
 
         summarize_description_config = values.get("summarize_descriptions") or {}

--- a/graphrag/config/input_models/community_reports_config_input.py
+++ b/graphrag/config/input_models/community_reports_config_input.py
@@ -15,3 +15,4 @@ class CommunityReportsConfigInput(LLMConfigInput):
     max_length: NotRequired[int | str | None]
     max_input_length: NotRequired[int | str | None]
     strategy: NotRequired[dict | None]
+    local_context_pruning_strategy: NotRequired[str | None]

--- a/graphrag/config/models/community_reports_config.py
+++ b/graphrag/config/models/community_reports_config.py
@@ -29,6 +29,10 @@ class CommunityReportsConfig(LLMConfig):
     strategy: dict | None = Field(
         description="The override strategy to use.", default=None
     )
+    
+    local_context_pruning_strategy: str | None = Field(
+        description="The local context pruning strategy to use.", default=None
+    )
 
     def resolved_strategy(self, root_dir) -> dict:
         """Get the resolved community report extraction strategy."""
@@ -45,4 +49,5 @@ class CommunityReportsConfig(LLMConfig):
             else None,
             "max_report_length": self.max_length,
             "max_input_length": self.max_input_length,
+            "local_context_pruning_strategy": self.local_context_pruning_strategy,
         }

--- a/graphrag/index/graph/extractors/community_reports/prep_community_report_context.py
+++ b/graphrag/index/graph/extractors/community_reports/prep_community_report_context.py
@@ -32,6 +32,7 @@ def prep_community_report_context(
     local_context_df: pd.DataFrame,
     level: int | str,
     max_tokens: int,
+    pruning_strategy: str,
 ) -> pd.DataFrame:
     """
     Prep context for each community in a given level.
@@ -53,7 +54,15 @@ def prep_community_report_context(
     if invalid_context_df.empty:
         return valid_context_df
 
-    if report_df.empty:
+    # check pruning strategy here
+    breakpoint()
+    if pruning_strategy == "degree":
+        # add using or condition on L63
+        pass
+
+    if report_df.empty: # when subcommunities don't exist, assumes levels is processed in bottom-up order
+        # (original) when bottom level of community hierarchy, no sub-communities. 
+        # Override to use this if pruning strategy == degree.
         invalid_context_df[schemas.CONTEXT_STRING] = _sort_and_trim_context(
             invalid_context_df, max_tokens
         )

--- a/graphrag/index/verbs/graph/report/create_community_reports.py
+++ b/graphrag/index/verbs/graph/report/create_community_reports.py
@@ -68,20 +68,20 @@ async def create_community_reports(
     
     
     """
-    local_contexts df:
+    local_contexts df (max_input_length=1000):
     all_contexts is a list of each entity's description in "node_details" along with incident edges in "edge_details"
-    community                                        all_context                                     context_string  context_size  context_exceed_limit  level
-0        10  [{'title': 'ALPACA', 'degree': 2, 'node_detail...  -----Entities-----\nhuman_readable_id,title,de...          1550                 False      2
+     community                                        all_context                                     context_string  context_size  context_exceed_limit  level
+0        10  [{'title': 'ALPACA', 'degree': 2, 'node_detail...  -----Entities-----\nhuman_readable_id,title,de...          1550                  True      2
 1         9  [{'title': 'LLM INFERENCE', 'degree': 1, 'node...  -----Entities-----\nhuman_readable_id,title,de...           173                 False      2
-0         4  [{'title': 'ALPACA', 'degree': 2, 'node_detail...  -----Entities-----\nhuman_readable_id,title,de...          1673                 False      1
+0         4  [{'title': 'ALPACA', 'degree': 2, 'node_detail...  -----Entities-----\nhuman_readable_id,title,de...          1673                  True      1
 1         5  [{'title': 'FASTER TRANSFORMER', 'degree': 3, ...  -----Entities-----\nhuman_readable_id,title,de...           416                 False      1
 2         6  [{'title': 'GPU', 'degree': 2, 'node_details':...  -----Entities-----\nhuman_readable_id,title,de...           321                 False      1
-3         7  [{'title': 'FASTERTRANSFORMER', 'degree': 7, '...  -----Entities-----\nhuman_readable_id,title,de...          1706                 False      1
+3         7  [{'title': 'FASTERTRANSFORMER', 'degree': 7, '...  -----Entities-----\nhuman_readable_id,title,de...          1706                  True      1
 4         8  [{'title': 'ORCA', 'degree': 8, 'node_details'...  -----Entities-----\nhuman_readable_id,title,de...           327                 False      1
-0         0  [{'title': 'ALPACA', 'degree': 2, 'node_detail...  -----Entities-----\nhuman_readable_id,title,de...          2146                 False      0
+0         0  [{'title': 'ALPACA', 'degree': 2, 'node_detail...  -----Entities-----\nhuman_readable_id,title,de...          2146                  True      0
 1         1  [{'title': 'COPY-ON-WRITE', 'degree': 2, 'node...  -----Entities-----\nhuman_readable_id,title,de...           793                 False      0
 2         2  [{'title': 'GPT', 'degree': 2, 'node_details':...  -----Entities-----\nhuman_readable_id,title,de...           277                 False      0
-3         3  [{'title': 'FASTERTRANSFORMER', 'degree': 7, '...  -----Entities-----\nhuman_readable_id,title,de...          1832                 False      0
+3         3  [{'title': 'FASTERTRANSFORMER', 'degree': 7, '...  -----Entities-----\nhuman_readable_id,title,de...          1832                  True      0
     
     example entity in all_contexts:
 
@@ -113,18 +113,23 @@ async def create_community_reports(
     # 2. make report solely based on local context
     # 3. if local context exceeds the limit, trim context based on degrees or ranking algorithms
     pruning_strategy = strategy.get("local_context_pruning_strategy", "none")
-    for level in levels:
+    if pruning_strategy == "degree":
+        levels = list(reversed(levels))
+    
+    for level in levels:    # level 0 is root level
+        time_start = pd.Timestamp.now()
         level_contexts = prep_community_report_context(
             pd.DataFrame(reports),
             local_context_df=local_contexts,
             community_hierarchy_df=community_hierarchy,
             level=level,
             max_tokens=strategy.get(
-                "max_input_tokens", defaults.COMMUNITY_REPORT_MAX_INPUT_LENGTH
+                # "max_input_tokens", defaults.COMMUNITY_REPORT_MAX_INPUT_LENGTH
+                "max_input_length", defaults.COMMUNITY_REPORT_MAX_INPUT_LENGTH
             ),
             pruning_strategy=pruning_strategy,
         )
-
+        
         async def run_generate(record):
             result = await _generate_report(
                 runner,
@@ -146,6 +151,8 @@ async def create_community_reports(
             scheduling_type=async_mode,
         )
         reports.extend([lr for lr in local_reports if lr is not None])
+        time_end = pd.Timestamp.now()
+        log.debug("[CR_GEN TIME] Level %s community report generation took %s", level, time_end - time_start)
     return TableContainer(table=pd.DataFrame(reports))
 
 

--- a/graphrag/index/verbs/graph/report/restore_community_hierarchy.py
+++ b/graphrag/index/verbs/graph/report/restore_community_hierarchy.py
@@ -44,7 +44,7 @@ def restore_community_hierarchy(
 
     community_hierarchy = []
 
-    for idx in range(len(levels) - 1):
+    for idx in range(len(levels) - 1):      ### why levels - 1, excludes final level?
         level = levels[idx]
         log.debug("Level: %s", level)
         next_level = levels[idx + 1]


### PR DESCRIPTION
-- added config field for pruning strategy
-- logging to measure time to generate community reports per level
-- reuse `_sort_and_trim_context` (uses degree-based pruning) for top-down CR generation

TODO: `restore_community_hierarchy` verb excludes final level in for loop 